### PR TITLE
Don't discard unsigned partitions in signed case

### DIFF
--- a/extractor.sh
+++ b/extractor.sh
@@ -106,7 +106,7 @@ MAGIC=$(head -c12 $romzip | tr -d '\0')
 if [[ $MAGIC == "OPPOENCRYPT!" ]] || [[ "$romzipext" == "ozip" ]]; then
     echo "ozip detected"
     cp $romzip "$tmpdir/temp.ozip"
-    python $ozipdecrypt "$tmpdir/temp.ozip"
+    python3 $ozipdecrypt "$tmpdir/temp.ozip"
     if [[ -d "$tmpdir/out" ]]; then
         7z a -r "$tmpdir/temp.zip" "$tmpdir/out/*"
     fi

--- a/extractor.sh
+++ b/extractor.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/usr/bin/env bash
 
 # Supported Firmwares:
 # Aonly OTA

--- a/extractor.sh
+++ b/extractor.sh
@@ -299,11 +299,13 @@ elif [[ $(7z l -ba $romzip | grep "system-p") ]]; then
 elif [[ $(7z l -ba $romzip | grep "system-sign.img") ]]; then
     echo "sign images detected"
     7z x -y $romzip 2>/dev/null >> $tmpdir/zip.log
+    for partition in $PARTITIONS; do
+        [[ -e "$tmpdir/$partition.img" ]] && mv "$tmpdir/$partition.img" "$outdir/$partition.img"
+    done
     find $tmpdir/ -name "* *" -type d,f | rename 's/ /_/g' > /dev/null 2>&1 # removes space from file name
     find $tmpdir/ -mindepth 2 -type f -name "*-sign.img" -exec mv {} . \; # move .img in sub-dir to $tmpdir
     find $tmpdir/ -type f ! -name "*-sign.img" -exec rm -rf {} \; # delete other files
     find "$tmpdir" -maxdepth 1 -type f -name "*-sign.img" | rename 's/-sign.img/.img/g' > /dev/null 2>&1 # proper .img names
-    mv "$tmpdir/boot.img" "$outdir/boot.img"
     sign_list=`find "$tmpdir" -maxdepth 1 -type f -name "*.img" -printf '%P\n' | sort`
     for file in $sign_list; do
         rm -rf "$tmpdir/x.img"

--- a/extractor.sh
+++ b/extractor.sh
@@ -126,7 +126,7 @@ if [[ $(echo $romzip | grep kdz) ]]; then
     exit 0
 fi
 
-if [[ $(echo $romzip | grep -i ruu_ | grep -i exe) ]]; then
+if [[ $(echo $romzip | grep -i ruu_ ) ]]; then
     echo "RUU detected"
     cp $romzip $tmpdir
     romzip="$tmpdir/$(basename $romzip)"

--- a/extractor.sh
+++ b/extractor.sh
@@ -88,7 +88,7 @@ splituapp="$toolsdir/splituapp"
 
 romzip="$(realpath $1)"
 romzipext=${romzip##*.}
-PARTITIONS="system vendor cust odm oem factory product xrom modem dtbo boot tz systemex oppo_product preload_common"
+PARTITIONS="system vendor cust odm oem factory product xrom modem dtbo boot tz systemex oppo_product preload_common system_ext system_other"
 EXT4PARTITIONS="system vendor cust odm oem factory product xrom systemex oppo_product preload_common"
 OTHERPARTITIONS="tz.mbn:tz tz.img:tz modem.img:modem NON-HLOS:modem boot-verified.img:boot dtbo-verified.img:dtbo"
 

--- a/patcher.sh
+++ b/patcher.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/usr/bin/env bash
 
 # Supported Firmwares:
 # AB OTA


### PR DESCRIPTION
In signed case, only partitions with -sign in their name are processed. In particular boot.img is discarded, is deleted before it can be moved.
Move possibly unsigned PARTITIONS before process the signed partitiosn